### PR TITLE
Fix link to Android Basics with Kotlin Course

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Starter code for Android Basics codelab - Store the data in a ViewModel
 Unscramble is  a single player game app that displays scrambled words. To play the game, player has
 to make a word using all the letters from the displayed scrambled word.
 
-Used in the [Android Basics with Kotlin](https://developer.android
-.com/courses/android-basics-kotlin/course) course.
+Used in the [Android Basics with Kotlin](https://developer.android.com/courses/android-basics-kotlin/course) course.
 
 
 Pre-requisites


### PR DESCRIPTION
Removed line break in link so link will display properly. This is consistent with the file in the "master" branch but those doing the android basics in Kotlin course will be using the starter branch.