### PR TITLE
Added a regex check to the onSubmitWord method of the GameFragment 

### DIFF
--- a/app/src/main/java/com/example/android/unscramble/ui/game/GameFragment.kt
+++ b/app/src/main/java/com/example/android/unscramble/ui/game/GameFragment.kt
@@ -71,7 +71,9 @@ class GameFragment : Fragment() {
     * After the last word, the user is shown a Dialog with the final score.
     */
     private fun onSubmitWord() {
-        val playerWord = binding.textInputEditText.text.toString()
+        val tempPlayerWord = binding.textInputEditText.text.toString()
+        val regex = "\\s+$".toRegex()
+        val playerWord = regex.replace(tempPlayerWord, "")
 
         if (viewModel.isUserWordCorrect(playerWord)) {
             setErrorTextField(false)


### PR DESCRIPTION
Added a regex check to the onSubmitWord method of the GameFragment to ensure trailing spaces in the submitted word (which could be present when the keyboard autocorrect suggests the word) do not affect the correctness of the summited word. The example screenshot included will show an error without the regex check when the answer is actually correct
![Screenshot_20230222-124841](https://user-images.githubusercontent.com/66222345/220612428-eda32909-552c-47b2-b624-bcdd1838e86b.png)
